### PR TITLE
Bookmark Entry: Toggle Notification Dot & Style

### DIFF
--- a/src/plugins/channelTabs/components/BookmarkContainer.tsx
+++ b/src/plugins/channelTabs/components/BookmarkContainer.tsx
@@ -94,10 +94,12 @@ function BookmarkFolderOpenMenu(props: BookmarkProps) {
         {bookmark.bookmarks.map((bkm, i) => <Menu.MenuItem
             key={`bookmark-folder-entry-${bkm.channelId}`}
             id={`bookmark-folder-entry-${bkm.channelId}`}
-            label={[
-                bkm.name,
-                <NotificationDot channelIds={[bkm.channelId]} />
-            ]}
+            label={
+                <div style={{ display: "flex", alignItems: "center", "gap": "0.25rem" }}>
+                    {bkm.name}
+                    {bookmarkNotificationDot && <NotificationDot channelIds={[bkm.channelId]} />}
+                </div>
+            }
             icon={() => <BookmarkIcon bookmark={bkm} />}
             showIconFirst={true}
             action={() => switchChannel(bkm)}

--- a/src/plugins/channelTabs/components/BookmarkContainer.tsx
+++ b/src/plugins/channelTabs/components/BookmarkContainer.tsx
@@ -96,7 +96,9 @@ function BookmarkFolderOpenMenu(props: BookmarkProps) {
             id={`bookmark-folder-entry-${bkm.channelId}`}
             label={
                 <div style={{ display: "flex", alignItems: "center", "gap": "0.25rem" }}>
-                    {bkm.name}
+                    <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+                        {bkm.name}
+                    </span>
                     {bookmarkNotificationDot && <NotificationDot channelIds={[bkm.channelId]} />}
                 </div>
             }


### PR DESCRIPTION
Toggle `NotificationDot` with the setting. Also some screenshots showed that notifications were displayed side-by-side in bookmark entries, but they weren't for me:
![QMB9L](https://github.com/Vendicated/Vencord/assets/30734036/5e8cdfc1-03e8-4e18-9bc2-c2ea2320f481)

Now:
![uYdAl](https://github.com/Vendicated/Vencord/assets/30734036/e761516b-f75e-41fe-bd0b-6ad7726f88bb)